### PR TITLE
Require Active Support rather than Rails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
-### 0.0.2 (Next)
+### 0.0.3 (Next)
 
 * Your contribution here.
+
+### 0.0.2 (2/25/2015)
+
+* Use Active Support as a gem dependency rather than Rails - [@dylanfareed](https://github.com/dylanfareed).
 
 ### 0.0.1 (6/4/2014)
 

--- a/hashie_rails.gemspec
+++ b/hashie_rails.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.rdoc']
   s.test_files = Dir['test/**/*']
 
-  s.add_dependency 'rails', '~> 4.0'
+  s.add_dependency 'activesupport', '~> 4.0'
   s.add_dependency 'hashie', '>= 3.0'
 
   if RUBY_PLATFORM != 'java'
@@ -26,5 +26,6 @@ Gem::Specification.new do |s|
   end
 
   s.add_development_dependency 'minitest'
+  s.add_development_dependency 'rails', '~> 4.0'
   s.add_development_dependency 'grape'
 end

--- a/lib/hashie_rails/version.rb
+++ b/lib/hashie_rails/version.rb
@@ -1,3 +1,3 @@
 module HashieRails
-  VERSION = '0.0.1'
+  VERSION = '0.0.2'
 end


### PR DESCRIPTION
It would be nice to take advantage of hashie_rails without needing to include Rails in a project (in a Grape + Rack app for example). It appears that ActiveSupport is the actual dependency here. This moves Rails to development dependency. 